### PR TITLE
fix pointcloud and add pointcloud example

### DIFF
--- a/examples/PeopleCounting_demo/PeopleCounting_demo.ino
+++ b/examples/PeopleCounting_demo/PeopleCounting_demo.ino
@@ -16,6 +16,7 @@ SEEED_MR60BHA2 mmWave;
 void setup() {
   Serial.begin(115200);
   mmWave.begin(&mmWaveSerial);
+  mmWave.setUserLog(1);
 }
 
 void loop() {
@@ -34,6 +35,7 @@ void loop() {
             Serial.printf("Target %zu:\n", i + 1);
             Serial.printf("  x_point: %.2f\n", target.x_point);
             Serial.printf("  y_point: %.2f\n", target.y_point);
+            Serial.printf("  z_point: %.2f\n", target.z_point);
             Serial.printf("  dop_index: %d\n", target.dop_index);
             Serial.printf("  cluster_index: %d\n", target.cluster_index);
             Serial.printf("  move_speed: %.2f cm/s\n", target.dop_index * RANGE_STEP);

--- a/examples/PeopleCounting_demo/PeopleCounting_demo.ino
+++ b/examples/PeopleCounting_demo/PeopleCounting_demo.ino
@@ -38,7 +38,7 @@ void loop() {
             Serial.printf("  z_point: %.2f\n", target.z_point);
             Serial.printf("  dop_index: %d\n", target.dop_index);
             Serial.printf("  cluster_index: %d\n", target.cluster_index);
-            Serial.printf("  move_speed: %.2f cm/s\n", target.dop_index * RANGE_STEP);
+            Serial.printf("  move_speed: %.2f cm/s\n", target.dop_index * 100);
         }
     }
     // delay(500);

--- a/examples/PointCloud_demo/PointCloud_demo.ino
+++ b/examples/PointCloud_demo/PointCloud_demo.ino
@@ -55,7 +55,7 @@ void loop() {
         Serial.printf("  dop_index: %f\n", target.dop_index);
         Serial.printf("  cluster_index: %f\n", target.cluster_index);
         Serial.printf("  move_speed: %.2f cm/s\n",
-                      target.dop_index * RANGE_STEP);
+                      target.dop_index * 100);
       }
     }
   }

--- a/examples/PointCloud_demo/PointCloud_demo.ino
+++ b/examples/PointCloud_demo/PointCloud_demo.ino
@@ -1,0 +1,64 @@
+#include <Arduino.h>
+
+#include "Seeed_Arduino_mmWave.h"
+
+// If the board is an ESP32, include the HardwareSerial library and create a
+// HardwareSerial object for the mmWave serial communication
+#ifdef ESP32
+#  include <HardwareSerial.h>
+HardwareSerial mmWaveSerial(0);
+#else
+// Otherwise, define mmWaveSerial as Serial1
+#  define mmWaveSerial Serial1
+#endif
+
+SEEED_MR60FDA2 mmWave;
+uint32_t sensitivity = 15;
+float height = 2.8, threshold = 1.0;
+float rect_XL, rect_XR, rect_ZF, rect_ZB;
+void setup() {
+  Serial.begin(115200);
+  mmWave.begin(&mmWaveSerial);
+  mmWave.setUserLog(1);
+  
+ 
+
+  /** get new parameters of mmwave **/
+  if (mmWave.getRadarParameters(height, threshold, sensitivity, rect_XL,
+                                rect_XR, rect_ZF, rect_ZB)) {
+    Serial.printf("height: %.2f\tthreshold: %.2f\tsensitivity: %d\n", height,
+                  threshold, sensitivity);
+    Serial.printf(
+        "rect_XL: %.2f\trect_XR: %.2f\trect_ZF: %.2f\trect_ZB: %.2f\n", rect_XL,
+        rect_XR, rect_ZF, rect_ZB);
+  } else {
+    Serial.println("getRadarParameters failed");
+  }
+}
+
+void loop() {
+  if (mmWave.update(100)) {
+    
+    PeopleCounting target_info;
+    if (mmWave.getPeopleCountingPointCloud(target_info)) {
+      //Serial.printf("-----Got Target Info-----\n");
+      //Serial.printf("Number of targets: %zu\n", target_info.targets.size());
+      if(target_info.targets.size() > 0){
+        Serial.printf("Number of targets: %zu\n", target_info.targets.size());
+      }
+      for (size_t i = 0; i < target_info.targets.size(); i++) {
+        const auto& target = target_info.targets[i];
+        Serial.printf("Target %zu:\n", i + 1);
+        Serial.printf("  x_point: %.2f\n", target.x_point);
+        Serial.printf("  y_point: %.2f\n", target.y_point);
+        Serial.printf("  z_point: %.2f\n", target.z_point);
+        Serial.printf("  dop_index: %f\n", target.dop_index);
+        Serial.printf("  cluster_index: %f\n", target.cluster_index);
+        Serial.printf("  move_speed: %.2f cm/s\n",
+                      target.dop_index * RANGE_STEP);
+      }
+    }
+  }
+
+  // delay(500);
+}

--- a/examples/gui_firmware/gui_firmware.ino
+++ b/examples/gui_firmware/gui_firmware.ino
@@ -1,0 +1,40 @@
+//This example is for GUI software
+
+#include <Arduino.h>
+#include "Seeed_Arduino_mmWave.h"
+
+// If the board is an ESP32, include the HardwareSerial library and create a
+// HardwareSerial object for the mmWave serial communication
+#ifdef ESP32
+#  include <HardwareSerial.h>
+HardwareSerial mmWaveSerial(0);
+#else
+// Otherwise, define mmWaveSerial as Serial1
+#  define mmWaveSerial Serial1
+#endif
+SEEED_MR60FDA2 mmWave;
+void setup() {
+  // Initialize the serial communication for debugging
+  Serial.begin(115200);
+  while (!Serial) {
+    ; // Wait for Serial to initialize
+  }
+  mmWave.begin(&mmWaveSerial);
+  mmWave.setUserLog(1);
+  // Initialize the mmWaveSerial communication
+  mmWaveSerial.begin(115200);
+}
+
+void loop() {
+  // Check if there is data available from mmWaveSerial
+  while (mmWaveSerial.available() > 0) {
+    char receivedChar = mmWaveSerial.read();
+    Serial.write(receivedChar); // Forward data to Serial
+  }
+
+  // Check if there is data available from Serial
+  while (Serial.available() > 0) {
+    char receivedChar = Serial.read();
+    mmWaveSerial.write(receivedChar); // Forward data to mmWaveSerial
+  }
+}

--- a/src/SEEED_MR60BHA2.cpp
+++ b/src/SEEED_MR60BHA2.cpp
@@ -46,7 +46,7 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
       break;
     }
     case TypeHeartBreath::Report3DPointCloudDetection: {
-      size_t target_num = extractU32(data);  // Extract target quantity
+      int32_t target_num = (int32_t)extractI32(data);  // Extract target quantity
       data += sizeof(uint32_t);
 
       std::vector<TargetN> received_targets; // Used to store parsed target data
@@ -55,17 +55,22 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
       for(size_t i = 0; i < target_num; i++)
       {
         TargetN target;
+        target.cluster_index = extractI32(data);
+        data += sizeof(int32_t);
+
         target.x_point = extractFloat(data);
         data += sizeof(float);
 
         target.y_point = extractFloat(data);
         data += sizeof(float);
 
-        target.dop_index = extractU32(data);
-        data += sizeof(int32_t);
+        target.z_point = extractFloat(data);
+        data += sizeof(float);
 
-        target.cluster_index = extractU32(data);
-        data += sizeof(int32_t);
+        target.dop_index = extractFloat(data);
+        data += sizeof(float);
+
+        
 
         received_targets.push_back(target); // Add the resolved target to the container
       }
@@ -76,8 +81,9 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
 
       break;
     }
+
     case TypeHeartBreath::Report3DPointCloudTartgetInfo: {
-      size_t target_num = extractU32(data);  // Extract target quantity
+      int32_t target_num = (int32_t)extractI32(data);  // Extract target quantity
       data += sizeof(uint32_t);
 
       std::vector<TargetN> received_targets; // Used to store parsed target data
@@ -86,17 +92,22 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
       for(size_t i = 0; i < target_num; i++)
       {
         TargetN target;
+        target.cluster_index = extractI32(data);
+        data += sizeof(int32_t);
+
         target.x_point = extractFloat(data);
         data += sizeof(float);
 
         target.y_point = extractFloat(data);
         data += sizeof(float);
 
-        target.dop_index = extractU32(data);
-        data += sizeof(int32_t);
+        target.z_point = extractFloat(data);
+        data += sizeof(float);
 
-        target.cluster_index = extractU32(data);
-        data += sizeof(int32_t);
+        target.dop_index = extractFloat(data);
+        data += sizeof(float);
+
+        
 
         received_targets.push_back(target); // Add the resolved target to the container
       }
@@ -165,6 +176,8 @@ bool SEEED_MR60BHA2::getPeopleCountingTartgetInfo(PeopleCounting& target_info) {
   target_info = std::move(_people_counting_target_info);
   return true;
 }
+
+
 
 bool SEEED_MR60BHA2::isHumanDetected() {
   if (!_isHumanDetectionValid)

--- a/src/SEEED_MR60BHA2.h
+++ b/src/SEEED_MR60BHA2.h
@@ -14,7 +14,7 @@
 #define SEEED_MR60BHA2_H
 
 #include "SeeedmmWave.h"
-
+#include "SEEED_Public.h"
 #define MAX_TARGET_NUM    3
 
 #define RANGE_STEP 17.28f
@@ -35,16 +35,7 @@ typedef struct HeartBreath {
   float heart_phase;
 } HeartBreath;
 
-typedef struct TargetN {
-  float x_point;
-  float y_point;
-  int32_t dop_index;
-  int32_t cluster_index;
-} TargetN;
 
-typedef struct PeopleCounting {
-  std::vector<TargetN> targets;
-} PeopleCounting;
 
 class SEEED_MR60BHA2 : public SeeedmmWave {
  private:

--- a/src/SEEED_MR60FDA2.h
+++ b/src/SEEED_MR60FDA2.h
@@ -13,7 +13,7 @@
 #define SEEED_MR60FDA2_H
 
 #include "SeeedmmWave.h"
-
+#include "SEEED_Public.h"
 enum class TypeFallDetection : uint16_t {
   UserLogInfo = 0x010E,
 
@@ -43,6 +43,8 @@ class SEEED_MR60FDA2 : public SeeedmmWave {
   float _rect_ZF;
   float _rect_ZB;
 
+
+
   /*set height*/
   bool _isHeightValid = false;
   bool _isThresholdValid;    // 0 : Failed to obtain  1 : acquisition successful
@@ -59,6 +61,14 @@ class SEEED_MR60FDA2 : public SeeedmmWave {
   bool _isFallValid  = false;
 
   bool getFallInternal();
+
+  /* PeopleCounting PointCloud */
+  PeopleCounting _people_counting_point_cloud;
+  bool _isPeopleCountingPointCloudValid;
+ 
+  /* PeopleCounting TartgetInfo */
+  PeopleCounting _people_counting_target_info;
+  bool _isPeopleCountingTartgetInfoValid;
  protected:
   bool getRadarParameters();
 
@@ -87,7 +97,9 @@ class SEEED_MR60FDA2 : public SeeedmmWave {
                           float& rect_ZF, float& rect_ZB);
 
   // bool get3DPointCloud(const int option);
-
+  bool getPeopleCountingPointCloud(PeopleCounting& point_cloud);
+  bool getPeopleCountingTartgetInfo(PeopleCounting& target_info);
+  
   bool getFall(bool &is_fall);
   bool getHuman(bool &is_human);
   bool getFall();

--- a/src/SEEED_Public.h
+++ b/src/SEEED_Public.h
@@ -1,0 +1,17 @@
+#ifndef SEEED_PUBLIC_H
+#define SEEED_PUBLIC_H
+
+#include "SeeedmmWave.h"
+typedef struct TargetN {
+  float x_point;
+  float y_point;
+  float z_point;
+  float dop_index;
+  int32_t cluster_index;
+} TargetN;
+
+typedef struct PeopleCounting {
+  std::vector<TargetN> targets;
+} PeopleCounting;
+
+#endif

--- a/src/SeeedmmWave.cpp
+++ b/src/SeeedmmWave.cpp
@@ -167,7 +167,9 @@ float SeeedmmWave::extractFloat(const uint8_t* bytes) const {
 uint32_t SeeedmmWave::extractU32(const uint8_t* bytes) const {
   return *reinterpret_cast<const uint32_t*>(bytes);
 }
-
+int32_t SeeedmmWave::extractI32(const uint8_t* bytes) const{
+  return *reinterpret_cast<const int32_t*>(bytes);
+}
 /**
  * @brief Initialize the SeeedmmWave object.
  *
@@ -361,7 +363,7 @@ void SeeedmmWave::fetch(uint32_t timeout) {
         if (frameBuffer.size() >= SIZE_FRAME_HEADER)  // right package
         {
           frameDataSize = (frameBuffer[3] << 8 | frameBuffer[4]);
-          if (frameDataSize > 30) {
+          if (frameDataSize > 360) {
             startFrame = false;
             // Serial.println("FrameDataSize too large, clearing buffer");
             continue;

--- a/src/SeeedmmWave.h
+++ b/src/SeeedmmWave.h
@@ -55,7 +55,7 @@
 
 #endif
 
-#define MMWaveMaxQueueSize 120
+#define MMWaveMaxQueueSize 360
 
 class SeeedmmWave {
  private:
@@ -72,6 +72,7 @@ class SeeedmmWave {
                         uint8_t expected_checksum);
   float extractFloat(const uint8_t* bytes) const;
   uint32_t extractU32(const uint8_t* bytes) const;
+  int32_t extractI32(const uint8_t* bytes) const;
   void floatToBytes(float value, uint8_t* bytes);
   void uint32ToBytes(uint32_t value, uint8_t* bytes);
 


### PR DESCRIPTION
fix point cloud handling and add point cloud example

- fix  case Report3DPointCloudTartgetInfo and Report3DPointCloudDetection on handletype function using [MR60FDA2 Tiny Frame Interface Manual](https://wiki.seeedstudio.com/getting_started_with_mr60fda2_mmwave_kit/#resources)
- fix PeopleCounting_demo.ino: setUserLog to 1 to obtain the target information(0A04)
- add PointCloud_demo.ino: example for obtaining point cloud information(0A08)
- add gui_firmware.ino: ESP32C6 firmware for [GUI tools](https://wiki.seeedstudio.com/getting_started_with_mr60fda2_mmwave_kit/#resources)
- Increase queue size to obtain 3D point cloud information
