### PR TITLE
fix: buffer size should be set before HardwareSerial.begin

### DIFF
--- a/src/SeeedmmWave.cpp
+++ b/src/SeeedmmWave.cpp
@@ -186,9 +186,10 @@ void SeeedmmWave::begin(HardwareSerial* serial, uint32_t baud,
   this->_baud       = baud;
   this->_wait_delay = wait_delay;
 
+  _serial->setRxBufferSize(1024 * 32);
   _serial->begin(_baud);
   _serial->setTimeout(1000);
-  _serial->setRxBufferSize(1024 * 32);
+
   // _serial->setRxFIFOFull(20);
   if (rst >= 0) {
     pinMode(rst, OUTPUT);


### PR DESCRIPTION
Per HardwareSerial implementation in ESP32, "RX Buffer can't be resized when Serial is already running."