### PR TITLE
Fix typo: 'Tartget' to 'Target' in API and enums

### DIFF
--- a/examples/PeopleCounting_demo/PeopleCounting_demo.ino
+++ b/examples/PeopleCounting_demo/PeopleCounting_demo.ino
@@ -25,7 +25,7 @@ void loop() {
     }
 
     PeopleCounting target_info;
-    if (mmWave.getPeopleCountingTartgetInfo(target_info)) {
+    if (mmWave.getPeopleCountingTargetInfo(target_info)) {
         Serial.printf("-----Got Target Info-----\n");
         Serial.printf("Number of targets: %zu\n", target_info.targets.size());
 

--- a/src/SEEED_MR60BHA2.cpp
+++ b/src/SEEED_MR60BHA2.cpp
@@ -76,7 +76,7 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
 
       break;
     }
-    case TypeHeartBreath::Report3DPointCloudTartgetInfo: {
+    case TypeHeartBreath::Report3DPointCloudTargetInfo: {
       size_t target_num = extractU32(data);  // Extract target quantity
       data += sizeof(uint32_t);
 
@@ -103,7 +103,7 @@ bool SEEED_MR60BHA2::handleType(uint16_t _type, const uint8_t* data,
 
       // Store the received target data in the PeopleCounting object
       _people_counting_target_info.targets = std::move(received_targets);
-      _isPeopleCountingTartgetInfoValid = true;
+      _isPeopleCountingTargetInfoValid = true;
 
       break;
     }
@@ -163,10 +163,10 @@ bool SEEED_MR60BHA2::getPeopleCountingPointCloud(PeopleCounting& point_cloud) {
   return true;
 }
 
-bool SEEED_MR60BHA2::getPeopleCountingTartgetInfo(PeopleCounting& target_info) {
-  if (!_isPeopleCountingTartgetInfoValid)
+bool SEEED_MR60BHA2::getPeopleCountingTargetInfo(PeopleCounting& target_info) {
+  if (!_isPeopleCountingTargetInfoValid)
     return false;
-  _isPeopleCountingTartgetInfoValid = false;
+  _isPeopleCountingTargetInfoValid = false;
   target_info = std::move(_people_counting_target_info);
   return true;
 }

--- a/src/SEEED_MR60BHA2.h
+++ b/src/SEEED_MR60BHA2.h
@@ -25,7 +25,7 @@ enum class TypeHeartBreath : uint16_t {
   TypeHeartRate           = 0x0A15,
   TypeHeartBreathDistance = 0x0A16,
   Report3DPointCloudDetection   = 0x0A08,
-  Report3DPointCloudTartgetInfo = 0x0A04,
+  Report3DPointCloudTargetInfo = 0x0A04,
   ReportHumanDetection       = 0x0F09,
   ReportFirmware          = 0xFFFF,
 };
@@ -82,9 +82,9 @@ class SEEED_MR60BHA2 : public SeeedmmWave {
   PeopleCounting _people_counting_point_cloud;
   bool _isPeopleCountingPointCloudValid;
  
-  /* PeopleCounting TartgetInfo */
+  /* PeopleCounting TargetInfo */
   PeopleCounting _people_counting_target_info;
-  bool _isPeopleCountingTartgetInfoValid;
+  bool _isPeopleCountingTargetInfoValid;
 
 
   FirmwareInfo _firmware_info;
@@ -109,7 +109,7 @@ class SEEED_MR60BHA2 : public SeeedmmWave {
   bool getHeartRate(float& rate);
   bool getDistance(float& distance);
   bool getPeopleCountingPointCloud(PeopleCounting& point_cloud);
-  bool getPeopleCountingTartgetInfo(PeopleCounting& target_info);
+  bool getPeopleCountingTargetInfo(PeopleCounting& target_info);
   bool isHumanDetected();
   bool getFirmwareInfo(FirmwareInfo& firmware_info);
 };

--- a/src/SEEED_MR60FDA2.h
+++ b/src/SEEED_MR60FDA2.h
@@ -27,7 +27,7 @@ enum class TypeFallDetection : uint16_t {
   AlarmParameters               = 0x0E0C,
   RadarInitSetting              = 0x2110,
   Report3DPointCloudDetection   = 0x0A08,
-  Report3DPointCloudTartgetInfo = 0x0A04,
+  Report3DPointCloudTargetInfo = 0x0A04,
   ReportUnmannedDetection       = 0x0F09,
 };
 


### PR DESCRIPTION
Corrects the spelling of 'Tartget' to 'Target' in function names, variable names, and enum values across the PeopleCounting demo and SEEED_MR60BHA2/SEEED_MR60FDA2 source files for improved code clarity and consistency.