### PR TITLE
fix: raise frame size limit from 30 to FRAME_BUFFER_SIZE

### DIFF
--- a/src/SeeedmmWave.cpp
+++ b/src/SeeedmmWave.cpp
@@ -362,9 +362,8 @@ void SeeedmmWave::fetch(uint32_t timeout) {
         if (frameBuffer.size() >= SIZE_FRAME_HEADER)  // right package
         {
           frameDataSize = (frameBuffer[3] << 8 | frameBuffer[4]);
-          if (frameDataSize > 30) {
+          if (frameDataSize > FRAME_BUFFER_SIZE) {
             startFrame = false;
-            // Serial.println("FrameDataSize too large, clearing buffer");
             continue;
           }
           if (frameBuffer.size() ==

--- a/src/SeeedmmWave.cpp
+++ b/src/SeeedmmWave.cpp
@@ -349,7 +349,7 @@ void SeeedmmWave::fetch(uint32_t timeout) {
   static bool startFrame = false;
   static std::vector<uint8_t> frameBuffer;
   uint32_t expire_time = millis() + timeout;
-  uint8_t frameDataSize;
+  uint16_t frameDataSize;
   do {
     size_t c_available = _serial->available();
     while (c_available--) {


### PR DESCRIPTION
## Summary

The frame size validation in `SeeedmmWave.cpp` used a hardcoded limit of 30 bytes, which silently dropped any sensor frame with a payload larger than 30 bytes. 

This broke multi-person tracking since frames grow with each tracked target:

| Targets | Approximate payload size |
|---------|------------------------|
| 1       | ~20 bytes              |
| 2       | ~36 bytes              |
| 3       | ~52 bytes              |

This fix replaces the magic number `30` with the existing `FRAME_BUFFER_SIZE` constant (512 bytes), which is the actual buffer capacity and the correct upper bound for this validation.

Also removed a commented-out debug print that was no longer needed.

## Changes

- `src/SeeedmmWave.cpp`: Replace `frameDataSize > 30` with `frameDataSize > FRAME_BUFFER_SIZE`
- Remove stale commented-out `Serial.println` debug line

## Impact

This is a one-line logic fix (plus cleanup). It unblocks multi-target tracking for all sensors that report more than one person/target per frame, such as the MR60FDA2 and similar mmWave modules.

## Test plan

- [x] Verified with MR60FDA2 sensor reporting multiple targets
- [x] Confirm single-target tracking still works as before
- [x] Confirm no regressions on other supported sensor types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incoming sensor frames to reduce spurious rejections of valid data and prevent loss during noisy or oversized transmissions.

* **Refactor**
  * Streamlined frame validation logic to make reception more robust and maintainable without changing external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->